### PR TITLE
chore: add `layers` input to build-quay-main workflow

### DIFF
--- a/.github/workflows/build-quay-main.yml
+++ b/.github/workflows/build-quay-main.yml
@@ -19,7 +19,7 @@ on:
       layers:
         required: false
         type: boolean
-        default: false
+        default: true
     secrets:
       QUAY_USERNAME:
         required: true

--- a/.github/workflows/build-quay-main.yml
+++ b/.github/workflows/build-quay-main.yml
@@ -16,6 +16,10 @@ on:
       build-args:
         required: false
         type: string
+      layers:
+        required: false
+        type: boolean
+        default: false
     secrets:
       QUAY_USERNAME:
         required: true
@@ -42,6 +46,7 @@ jobs:
         uses: redhat-actions/buildah-build@v2
         with:
           image: ${{ inputs.service-name }}
+          layers: ${{ inputs.layers }}
           tags: ${{ github.sha }} ${{ inputs.docker-tag }}
           dockerfiles: |
             ./Dockerfile


### PR DESCRIPTION
## Description

According to [redhat-actions/buildah-build](https://github.com/redhat-actions/buildah-build), the layers param: 
```Set to true to cache intermediate layers during the build process.```