### PR TITLE
chore: Update actions to use node 20

### DIFF
--- a/.github/workflows/build-quay-main.yml
+++ b/.github/workflows/build-quay-main.yml
@@ -40,10 +40,10 @@ jobs:
       registry-path: ${{ steps.push-to-quay.outputs.registry-path }}
       registry-paths: ${{ steps.push-to-quay.outputs.registry-paths }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.4
       - name: Build Image
         id: build-image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@v2.13
         with:
           image: ${{ inputs.service-name }}
           layers: ${{ inputs.layers }}
@@ -57,7 +57,7 @@ jobs:
       # in which case 'username' and 'password' can be omitted.
       - name: Push To quay.io
         id: push-to-quay
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@v2.8
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}


### PR DESCRIPTION
This PR updates the actions to use Node 20 instead of Node 16 which is prompt to be deprecated.