### PR TITLE
feat: update pr title validation

### DIFF
--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,31 +1,34 @@
 name: Validate PR Title
 
 on:
-  pull_request:
-    types: [edited, opened, reopened, synchronize]
-  workflow_call:
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize]
 
 permissions:
-  contents: read
   pull-requests: read
 
 jobs:
-  title-matches-convention:
+  semantic:
     runs-on: ubuntu-latest
     steps:
-      - uses: 8BitJonny/gh-get-current-pr@2.2.0
-        id: PR
+      - uses: amannn/action-semantic-pull-request@v5
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          sha: ${{ github.event.pull_request.head.sha }}
-      - uses: actions-ecosystem/action-regex-match@v2
-        id: regex-match
-        with:
-          text: ${{ steps.PR.outputs.pr_title }}
-          regex: '^(break|chore|docs|feat|fix|refactor|revert|style|test)(\(.+\))?: .+$'
-          flags: gs
+          types: |
+            break
+            chore
+            docs
+            feat
+            fix
+            refactor
+            revert
+            style
+            test
+            release
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$ # No uppercase first letter
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
         env:
-          prTitle: ${{ steps.PR.outputs.pr_title }}
-      - run: echo "Regex found [${{ steps.regex-match.outputs.match }}]"
-      - run: echo "::error title=PR's title (${{steps.PR.outputs.pr_title}}) does not match the convention::Please refer to https://github.com/decentraland/catalyst/blob/main/docs/CONTRIBUTING.md#creating-a-pull-request and change the PR's title" && exit 1
-        if: ${{ steps.regex-match.outputs.match == '' }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -3,6 +3,7 @@ name: Validate PR Title
 on:
   pull_request_target:
     types: [opened, reopened, edited, synchronize]
+  workflow_call:
 
 permissions:
   pull-requests: read

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  semantic:
+  title-matches-convention:
     runs-on: ubuntu-latest
     steps:
       - uses: decentraland/action-semantic-pull-request@main

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -12,7 +12,7 @@ jobs:
   title-matches-convention:
     runs-on: ubuntu-latest
     steps:
-      - uses: decentraland/action-semantic-pull-request@main
+      - uses: decentraland/action-semantic-pull-request@v1
         with:
           types: |
             break

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -11,7 +11,7 @@ jobs:
   semantic:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: decentraland/action-semantic-pull-request@main
         with:
           types: |
             break


### PR DESCRIPTION
This changes the pr title validation workflow to use the https://github.com/decentraland/action-semantic-pull-request action.

This does a similar job as our existing workflow, and it will verify the following:

- type is one of: `feat,fix,docs,style,refactor,test,chore,revert,break,release` (`release` added for sync commits in Explorer when releases are merged)
- Scope is not required but CAN be added (we can change this to completely disallow scopes)
- Subject cannot start with an upper case letter. So `feat: Add new feature` would fail the check