### PR TITLE
fix: add --repo flag to pr-comment-reminder workflow

### DIFF
--- a/.github/workflows/pr-comment-reminder.yml
+++ b/.github/workflows/pr-comment-reminder.yml
@@ -21,4 +21,8 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           MESSAGE: ${{ inputs.message }}
         run: |
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::No pull request number found. This workflow must be triggered by a pull_request event."
+            exit 1
+          fi
           gh pr comment "$PR_NUMBER" --body "$MESSAGE"

--- a/.github/workflows/pr-comment-reminder.yml
+++ b/.github/workflows/pr-comment-reminder.yml
@@ -20,6 +20,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           MESSAGE: ${{ inputs.message }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           if [ -z "$PR_NUMBER" ]; then
             echo "::error::No pull request number found. This workflow must be triggered by a pull_request event."

--- a/.github/workflows/pr-comment-reminder.yml
+++ b/.github/workflows/pr-comment-reminder.yml
@@ -21,8 +21,4 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           MESSAGE: ${{ inputs.message }}
         run: |
-          curl -s -X POST \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Accept: application/vnd.github+v3+json" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
-            -d "$(jq -n --arg body "$MESSAGE" '{body: $body}')"
+          gh pr comment "$PR_NUMBER" --body "$MESSAGE"

--- a/.github/workflows/pr-comment-reminder.yml
+++ b/.github/workflows/pr-comment-reminder.yml
@@ -25,4 +25,4 @@ jobs:
             echo "::error::No pull request number found. This workflow must be triggered by a pull_request event."
             exit 1
           fi
-          gh pr comment "$PR_NUMBER" --body "$MESSAGE"
+          echo "$MESSAGE" | gh pr comment "$PR_NUMBER" --body-file -

--- a/.github/workflows/pr-comment-reminder.yml
+++ b/.github/workflows/pr-comment-reminder.yml
@@ -25,4 +25,4 @@ jobs:
             echo "::error::No pull request number found. This workflow must be triggered by a pull_request event."
             exit 1
           fi
-          echo "$MESSAGE" | gh pr comment "$PR_NUMBER" --body-file -
+          echo "$MESSAGE" | gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file -

--- a/.github/workflows/pr-comment-reminder.yml
+++ b/.github/workflows/pr-comment-reminder.yml
@@ -21,6 +21,8 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           MESSAGE: ${{ inputs.message }}
         run: |
-          gh api \
-            repos/${{ github.repository }}/issues/$PR_NUMBER/comments \
-            -f body="$MESSAGE"
+          curl -s -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+            -d "$(jq -n --arg body "$MESSAGE" '{body: $body}')"

--- a/.github/workflows/pr-comment-reminder.yml
+++ b/.github/workflows/pr-comment-reminder.yml
@@ -1,0 +1,26 @@
+name: PR Comment Reminder
+
+on:
+  workflow_call:
+    inputs:
+      message:
+        description: "The markdown message to post as a comment on the PR"
+        required: true
+        type: string
+
+permissions:
+  pull-requests: write
+
+jobs:
+  add-reminder-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add reminder comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MESSAGE: ${{ inputs.message }}
+        run: |
+          gh api \
+            repos/${{ github.repository }}/issues/$PR_NUMBER/comments \
+            -f body="$MESSAGE"


### PR DESCRIPTION
## Summary
Adds a reusable workflow that posts a reminder comment on pull requests. Calling repos can use it via `workflow_call` and pass a custom markdown message.

- No checkout step needed — uses `--repo "$GITHUB_REPOSITORY"` so `gh pr comment` works without local git context
- Validates that a PR number exists before attempting to comment
- Accepts a `message` input (required) with the markdown content to post

### Usage
```yaml
jobs:
  reminder:
    uses: decentraland/actions/.github/workflows/pr-comment-reminder.yml@main
    with:
      message: "Don't forget to update the changelog!"
```

## Test plan
- [X] Call the reusable workflow from another repo and verify the PR comment is posted successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)