### PR TITLE
fix: skip commit-SHA tag on release builds and block mutable tags on prd

### DIFF
--- a/.github/workflows/build-quay-main.yml
+++ b/.github/workflows/build-quay-main.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string
         default: latest
+      skip-commit-sha-tag:
+        required: false
+        type: boolean
+        default: false
+        description: "Do not tag the image with the commit SHA. Set on release/versioned builds whose trigger is not a release event (e.g. a release-branch push), so the SHA tag stays on the main build's digest."
       build-args:
         required: false
         type: string
@@ -47,7 +52,13 @@ jobs:
         with:
           image: ${{ inputs.service-name }}
           layers: ${{ inputs.layers }}
-          tags: ${{ github.sha }} ${{ inputs.docker-tag }}
+          # On main builds the image owns the commit-SHA tag, which dev/biz deployments pin by
+          # digest. On release/versioned builds, re-tagging the same SHA onto a separately built
+          # digest moves the tag off the main build's digest -> it goes untagged -> Quay GC reaps
+          # it -> tasks pinned to it fail with CannotPullContainerError. So skip the SHA tag on
+          # release events (and when skip-commit-sha-tag is set); publish the docker-tag only,
+          # which release callers set to the immutable version (also the deploy's registry-path).
+          tags: ${{ (github.event_name == 'release' || inputs.skip-commit-sha-tag) && inputs.docker-tag || format('{0} {1}', github.sha, inputs.docker-tag) }}
           dockerfiles: |
             ./Dockerfile
           build-args: |

--- a/.github/workflows/build-quay-main.yml
+++ b/.github/workflows/build-quay-main.yml
@@ -1,4 +1,4 @@
-name: docker
+name: Build, push & deploy image
 
 on:
   workflow_call:

--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -28,8 +28,11 @@ jobs:
         env:
           TAG: ${{ inputs.tag }}
         run: |
+          # Block latest/next, including a digest-pinned form (latest@sha256:…). A digest pin
+          # guarantees content but not persistence: once latest/next moves off that digest and no
+          # retained tag remains, Quay GC reaps it and prd fails to pull (CannotPullContainerError).
           case "$TAG" in
-            latest|next)
+            latest|next|latest@*|next@*)
               echo "::error::Refusing to deploy a mutable tag (latest/next) to prd. Pin an immutable version tag."
               exit 1 ;;
           esac

--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -21,11 +21,21 @@ jobs:
     name: "Deploy to: ${{ inputs.deployment-environment }}"
     runs-on: ubuntu-latest
     steps:
+      # prd must run an immutable reference. A mutable tag (latest/next) can be repointed, or its
+      # digest GC'd out from under a running task (CannotPullContainerError). Block it on prd.
+      - name: Block mutable tags on prd
+        if: ${{ inputs.deployment-environment == 'prd' }}
+        run: |
+          case "${{ inputs.tag }}" in
+            latest|next)
+              echo "::error::Refusing to deploy a mutable tag (latest/next) to prd. Pin an immutable version tag."
+              exit 1 ;;
+          esac
       - name: Trigger deployment
         id: deploy
         uses: decentraland/dcl-deploy-action@main
         with:
-          dockerImage: "quay.io/decentraland/${{ inputs.service-name }}:${{ input.tag }}"
+          dockerImage: "quay.io/decentraland/${{ inputs.service-name }}:${{ inputs.tag }}"
           serviceName: ${{ inputs.service-name }}
           env: ${{ inputs.deployment-environment }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -25,8 +25,10 @@ jobs:
       # digest GC'd out from under a running task (CannotPullContainerError). Block it on prd.
       - name: Block mutable tags on prd
         if: ${{ inputs.deployment-environment == 'prd' }}
+        env:
+          TAG: ${{ inputs.tag }}
         run: |
-          case "${{ inputs.tag }}" in
+          case "$TAG" in
             latest|next)
               echo "::error::Refusing to deploy a mutable tag (latest/next) to prd. Pin an immutable version tag."
               exit 1 ;;

--- a/.github/workflows/manual-deploy-service.yml
+++ b/.github/workflows/manual-deploy-service.yml
@@ -34,8 +34,10 @@ jobs:
       # digest GC'd out from under a running task (CannotPullContainerError). Block it on prd.
       - name: Block mutable tags on prd
         if: ${{ inputs.deployment-environment == 'prd' }}
+        env:
+          TAG: ${{ inputs.tag }}
         run: |
-          case "${{ inputs.tag }}" in
+          case "$TAG" in
             latest|next)
               echo "::error::Refusing to deploy a mutable tag (latest/next) to prd. Pin an immutable version tag."
               exit 1 ;;

--- a/.github/workflows/manual-deploy-service.yml
+++ b/.github/workflows/manual-deploy-service.yml
@@ -11,11 +11,11 @@ on:
         required: true
         type: choice
         options:
-          - prd
           - dev
+          - prd
           - stg
           - biz
-        default: prd
+        default: dev
         description: Target environment
       tag:
         required: true
@@ -30,6 +30,16 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.deployment-environment }}
     steps:
+      # prd must run an immutable reference. A mutable tag (latest/next) can be repointed, or its
+      # digest GC'd out from under a running task (CannotPullContainerError). Block it on prd.
+      - name: Block mutable tags on prd
+        if: ${{ inputs.deployment-environment == 'prd' }}
+        run: |
+          case "${{ inputs.tag }}" in
+            latest|next)
+              echo "::error::Refusing to deploy a mutable tag (latest/next) to prd. Pin an immutable version tag."
+              exit 1 ;;
+          esac
       - name: Trigger deployment
         id: deploy
         uses: decentraland/dcl-deploy-action@main

--- a/.github/workflows/manual-deploy-service.yml
+++ b/.github/workflows/manual-deploy-service.yml
@@ -1,4 +1,4 @@
-name: Deploy 'latest' tag to environment
+name: Manually deploy a service tag to an environment
 
 on:
   workflow_dispatch:

--- a/.github/workflows/manual-deploy-service.yml
+++ b/.github/workflows/manual-deploy-service.yml
@@ -37,8 +37,11 @@ jobs:
         env:
           TAG: ${{ inputs.tag }}
         run: |
+          # Block latest/next, including a digest-pinned form (latest@sha256:…). A digest pin
+          # guarantees content but not persistence: once latest/next moves off that digest and no
+          # retained tag remains, Quay GC reaps it and prd fails to pull (CannotPullContainerError).
           case "$TAG" in
-            latest|next)
+            latest|next|latest@*|next@*)
               echo "::error::Refusing to deploy a mutable tag (latest/next) to prd. Pin an immutable version tag."
               exit 1 ;;
           esac


### PR DESCRIPTION
- build-quay-main re-tagged ${{ github.sha }} on every build, including release/versioned builds. 
- When a release rebuilt a commit the main pipeline had already published, the SHA tag moved off the main-built digest (which dev/biz pin by digest); that digest then went untagged, Quay GC reaped it, and tasks failed with CannotPullContainerError.
- Release builds now skip the SHA tag (auto on release events, or via skip-commit-sha-tag), publishing the immutable version only.
- Also hardens the manual/deploy-latest workflows: default to dev, reject mutable latest/next on prd, and fix the input.tag typo.